### PR TITLE
Fix usage examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g node-gyp
 Once `node-gyp` is installed, install Flakeless.
 
 ```bash
-npm install flakeless
+npm install ms-flakeless
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ npm install flakeless
 ### Initialization:
 
 ```js
-const Flakeless = require('flakeless').Flakeless;
+const Flakeless = require('ms-flakeless');
 const flakeless = new Flakeless({
   epochStart: Date.now(),
   outputType: 'base64',


### PR DESCRIPTION
The package is actually called `ms-flakeless` and the require does not export a .Flakeless constructor, its returned directly by require.

This commit should make the code 100% copy-pastable to test out the package.